### PR TITLE
CBA_MiscItem compatibility

### DIFF
--- a/addons/XLA_FixedArsenal/functions/Inventory/fn_arsenal.sqf
+++ b/addons/XLA_FixedArsenal/functions/Inventory/fn_arsenal.sqf
@@ -809,6 +809,12 @@ switch _mode do {
 					if (_weaponTypeCategory != "VehicleWeapon") then {
 						private ["_weaponTypeSpecific","_weaponTypeID"];
 						_weaponTypeSpecific = _weaponType select 1;
+
+						// Set the weapon type for CBA Misc Items to "MineDetector" so it appears in the Misc Tab
+						if((configName _class) isKindOf ['CBA_MiscItem', configFile >> 'CfgWeapons']) then {
+							_weaponTypeSpecific = "MineDetector";
+						};
+
 						_weaponTypeID = -1;
 						{
 							if (_weaponTypeSpecific in _x) exitwith {_weaponTypeID = _foreachindex;};


### PR DESCRIPTION
## Aim of the pull request
This PR fixes the incompatibility of CBA_MiscItems with XLA_FixedArsenal (Reported in #34).

## Description of the problem
Before ACE and ACRE started using CBA_MiscItem, they used the Vanilla Minedetector as the [Base Class](https://github.com/acemod/ACE3/commit/30a8d2db7bc2920524f4ee04e5ba8a250559de8d#diff-7e318c81f1eaa970131e8c19cbf108c8L3), therefore all the Items showed up in the "Misc"-Tab of the Arsenal. The problem is, the new "CBA_MiscItem", which is used in the new version of ACE and ACRE as the Base Class, is [defined as a Bipod](https://github.com/CBATeam/CBA_A3/pull/744/files#diff-7e318c81f1eaa970131e8c19cbf108c8R5). For this reason `BIS_fnc_itemType` returns `["Item","AccessoryBipod"]` in [Line 807 of fn_arsenal](https://github.com/ImperialAlex/XLA_FixedArsenal/blob/master/addons/XLA_FixedArsenal/functions/Inventory/fn_arsenal.sqf#L807). This causes that `_weaponTypeID` [remains at -1](https://github.com/ImperialAlex/XLA_FixedArsenal/blob/master/addons/XLA_FixedArsenal/functions/Inventory/fn_arsenal.sqf#L814) for CBA_MiscItems, since `AccessoryBipod` is not present in the  [`INITTYPES` Macro](https://github.com/ImperialAlex/XLA_FixedArsenal/blob/master/addons/XLA_FixedArsenal/functions/Inventory/fn_arsenal.sqf#L109). As a result, the Items aren't showing up in the Arsenal Misc Tab.

## Description of the fix
We can simply check if the Item has `CBA_MiscItem` as parent and then set the `_weaponTypeSpecific ` to `MineDetector`. The `_weaponTypeID` will then be set to the correct index of the Misc Tab.